### PR TITLE
Version 1.4.0

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,32 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.10" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Embedded JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/buildSrc/src/main/kotlin/artifact.kt
+++ b/buildSrc/src/main/kotlin/artifact.kt
@@ -1,5 +1,5 @@
 val artifact = Artifact(
     group = "de.mr-pine.utils",
     id = "zoomables",
-    version = "1.2.2"
+    version = "1.3.0"
 )

--- a/buildSrc/src/main/kotlin/artifact.kt
+++ b/buildSrc/src/main/kotlin/artifact.kt
@@ -1,5 +1,5 @@
 val artifact = Artifact(
     group = "de.mr-pine.utils",
     id = "zoomables",
-    version = "1.3.0"
+    version = "1.4.0"
 )

--- a/zoomables/src/main/kotlin/de/mr_pine/zoomables/DoubleTapBehaviour.kt
+++ b/zoomables/src/main/kotlin/de/mr_pine/zoomables/DoubleTapBehaviour.kt
@@ -1,0 +1,7 @@
+package de.mr_pine.zoomables
+
+import androidx.compose.ui.geometry.Offset
+
+public fun interface DoubleTapBehaviour {
+    public fun onDoubleTap(offset: Offset)
+}

--- a/zoomables/src/main/kotlin/de/mr_pine/zoomables/DragGestureMode.kt
+++ b/zoomables/src/main/kotlin/de/mr_pine/zoomables/DragGestureMode.kt
@@ -4,4 +4,9 @@ public enum class DragGestureMode {
     DISABLED,
     PAN,
     SWIPE_GESTURES;
+
+    public companion object {
+        public val default: ZoomableState.() -> DragGestureMode =
+            { if (transformed) PAN else SWIPE_GESTURES }
+    }
 }

--- a/zoomables/src/main/kotlin/de/mr_pine/zoomables/ZoomableImage.kt
+++ b/zoomables/src/main/kotlin/de/mr_pine/zoomables/ZoomableImage.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.CoroutineScope
  * @param onSwipeLeft Optional function to run when user swipes from right to left - does nothing by default
  * @param onSwipeRight Optional function to run when user swipes from left to right - does nothing by default
  * @param dragGestureMode A function with a [ZoomableState] scope that returns a [DragGestureMode] value that signals which drag gesture should currently be active. By default panning is enabled when zoomed, else swipe gestures are enabled.
- * @param onDoubleTap Optional function to run when user double taps. Zooms in by 2x when scale is currently 1 and zooms out to scale = 1 when zoomed in when null (default)
+ * @param doubleTapBehaviour A [DoubleTapBehaviour] providing a [DoubleTapBehaviour.onDoubleTap]. As [DoubleTapBehaviour] is a [functional Interface](https://kotlinlang.org/docs/fun-interfaces.html) you can just provide a lambda as a `onDoubleTap`
  */
 @Composable
 public fun ZoomableImage(
@@ -36,7 +36,8 @@ public fun ZoomableImage(
     onSwipeLeft: () -> Unit = {},
     onSwipeRight: () -> Unit = {},
     dragGestureMode: ZoomableState.() -> DragGestureMode = { if (zoomed) DragGestureMode.SWIPE_GESTURES else DragGestureMode.PAN },
-    onDoubleTap: ((Offset) -> Unit)? = null
+    onTap: ((Offset) -> Unit)? = null,
+    doubleTapBehaviour: DoubleTapBehaviour? = zoomableState.DefaultDoubleTapBehaviour(coroutineScope = coroutineScope)
 ) {
     Zoomable(
         coroutineScope = coroutineScope,
@@ -44,7 +45,8 @@ public fun ZoomableImage(
         onSwipeLeft = onSwipeLeft,
         onSwipeRight = onSwipeRight,
         dragGestureMode = dragGestureMode,
-        onDoubleTap = onDoubleTap
+        onTap = onTap,
+        doubleTapBehaviour = doubleTapBehaviour
     ) {
         Image(bitmap = bitmap, contentDescription = contentDescription, modifier = modifier)
     }
@@ -61,7 +63,7 @@ public fun ZoomableImage(
  * @param onSwipeLeft Optional function to run when user swipes from right to left - does nothing by default
  * @param onSwipeRight Optional function to run when user swipes from left to right - does nothing by default
  * @param dragGestureMode A function with a [ZoomableState] scope that returns a [DragGestureMode] value that signals which drag gesture should currently be active. By default panning is enabled when zoomed, else swipe gestures are enabled.
- * @param onDoubleTap Optional function to run when user double taps. Zooms in by 2x when scale is currently 1 and zooms out to scale = 1 when zoomed in when null (default)
+ * @param doubleTapBehaviour A [DoubleTapBehaviour] providing a [DoubleTapBehaviour.onDoubleTap]. As [DoubleTapBehaviour] is a [functional Interface](https://kotlinlang.org/docs/fun-interfaces.html) you can just provide a lambda as a `onDoubleTap`
  */
 @Composable
 public fun ZoomableImage(
@@ -73,7 +75,8 @@ public fun ZoomableImage(
     onSwipeLeft: () -> Unit = {},
     onSwipeRight: () -> Unit = {},
     dragGestureMode: ZoomableState.() -> DragGestureMode = { if (zoomed) DragGestureMode.SWIPE_GESTURES else DragGestureMode.PAN },
-    onDoubleTap: ((Offset) -> Unit)? = null
+    onTap: ((Offset) -> Unit)? = null,
+    doubleTapBehaviour: DoubleTapBehaviour? = zoomableState.DefaultDoubleTapBehaviour(coroutineScope = coroutineScope)
 ) {
     Zoomable(
         coroutineScope = coroutineScope,
@@ -81,7 +84,8 @@ public fun ZoomableImage(
         onSwipeLeft = onSwipeLeft,
         onSwipeRight = onSwipeRight,
         dragGestureMode = dragGestureMode,
-        onDoubleTap = onDoubleTap
+        onTap = onTap,
+        doubleTapBehaviour = doubleTapBehaviour,
     ) {
         Image(
             imageVector = imageVector,
@@ -102,7 +106,7 @@ public fun ZoomableImage(
  * @param onSwipeLeft Optional function to run when user swipes from right to left - does nothing by default
  * @param onSwipeRight Optional function to run when user swipes from left to right - does nothing by default
  * @param dragGestureMode A function with a [ZoomableState] scope that returns a [DragGestureMode] value that signals which drag gesture should currently be active. By default panning is enabled when zoomed, else swipe gestures are enabled.
- * @param onDoubleTap Optional function to run when user double taps. Zooms in by 2x when scale is currently 1 and zooms out to scale = 1 when zoomed in when null (default)
+ * @param doubleTapBehaviour A [DoubleTapBehaviour] providing a [DoubleTapBehaviour.onDoubleTap]. As [DoubleTapBehaviour] is a [functional Interface](https://kotlinlang.org/docs/fun-interfaces.html) you can just provide a lambda as a `onDoubleTap`
  */
 @Composable
 public fun ZoomableImage(
@@ -114,7 +118,8 @@ public fun ZoomableImage(
     onSwipeLeft: () -> Unit = {},
     onSwipeRight: () -> Unit = {},
     dragGestureMode: ZoomableState.() -> DragGestureMode = { if (zoomed) DragGestureMode.SWIPE_GESTURES else DragGestureMode.PAN },
-    onDoubleTap: ((Offset) -> Unit)? = null
+    onTap: ((Offset) -> Unit)? = null,
+    doubleTapBehaviour: DoubleTapBehaviour? = zoomableState.DefaultDoubleTapBehaviour(coroutineScope = coroutineScope)
 ) {
     Zoomable(
         coroutineScope = coroutineScope,
@@ -122,7 +127,8 @@ public fun ZoomableImage(
         onSwipeLeft = onSwipeLeft,
         onSwipeRight = onSwipeRight,
         dragGestureMode = dragGestureMode,
-        onDoubleTap = onDoubleTap
+        onTap = onTap,
+        doubleTapBehaviour = doubleTapBehaviour
     ) {
         Image(painter = painter, contentDescription = contentDescription, modifier = modifier)
     }

--- a/zoomables/src/main/kotlin/de/mr_pine/zoomables/ZoomableImage.kt
+++ b/zoomables/src/main/kotlin/de/mr_pine/zoomables/ZoomableImage.kt
@@ -35,7 +35,7 @@ public fun ZoomableImage(
     contentDescription: String? = null,
     onSwipeLeft: () -> Unit = {},
     onSwipeRight: () -> Unit = {},
-    dragGestureMode: ZoomableState.() -> DragGestureMode = { if (zoomed) DragGestureMode.SWIPE_GESTURES else DragGestureMode.PAN },
+    dragGestureMode: ZoomableState.() -> DragGestureMode = DragGestureMode.default,
     onTap: ((Offset) -> Unit)? = null,
     doubleTapBehaviour: DoubleTapBehaviour? = zoomableState.DefaultDoubleTapBehaviour(coroutineScope = coroutineScope)
 ) {
@@ -74,7 +74,7 @@ public fun ZoomableImage(
     contentDescription: String? = null,
     onSwipeLeft: () -> Unit = {},
     onSwipeRight: () -> Unit = {},
-    dragGestureMode: ZoomableState.() -> DragGestureMode = { if (zoomed) DragGestureMode.SWIPE_GESTURES else DragGestureMode.PAN },
+    dragGestureMode: ZoomableState.() -> DragGestureMode = DragGestureMode.default,
     onTap: ((Offset) -> Unit)? = null,
     doubleTapBehaviour: DoubleTapBehaviour? = zoomableState.DefaultDoubleTapBehaviour(coroutineScope = coroutineScope)
 ) {
@@ -117,7 +117,7 @@ public fun ZoomableImage(
     contentDescription: String? = null,
     onSwipeLeft: () -> Unit = {},
     onSwipeRight: () -> Unit = {},
-    dragGestureMode: ZoomableState.() -> DragGestureMode = { if (zoomed) DragGestureMode.SWIPE_GESTURES else DragGestureMode.PAN },
+    dragGestureMode: ZoomableState.() -> DragGestureMode = DragGestureMode.default,
     onTap: ((Offset) -> Unit)? = null,
     doubleTapBehaviour: DoubleTapBehaviour? = zoomableState.DefaultDoubleTapBehaviour(coroutineScope = coroutineScope)
 ) {

--- a/zoomables/src/main/kotlin/de/mr_pine/zoomables/ZoomableState.kt
+++ b/zoomables/src/main/kotlin/de/mr_pine/zoomables/ZoomableState.kt
@@ -11,7 +11,9 @@ import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.runtime.*
 import androidx.compose.ui.geometry.Offset
 import de.mr_pine.zoomables.ZoomableState.Rotation.*
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlin.math.atan
 import kotlin.math.cos
 import kotlin.math.sin
@@ -38,11 +40,12 @@ private const val zoomedThreshold = 1.0E-3f
  * @property rotation The current rotation in degrees as [MutableState]<[Float]>
  * @property transformed `false` if [scale] is `1`, [offset] is [Offset.Zero] and [rotation] is `0`
  * @property zoomed Whether the content is zoomed (in or out)
+ * @property composableCenter The position of the content's center relative to the [Zoomable] Container when [offset] is [Offset.Zero]. Might break when this State is used for multiple [Zoomable]s
  */
 public class ZoomableState(
-    public var scale: MutableState<Float>,
-    public var offset: MutableState<Offset>,
-    public var rotation: MutableState<Float>,
+    public val scale: MutableState<Float>,
+    public val offset: MutableState<Offset>,
+    public val rotation: MutableState<Float>,
     public val rotationBehavior: Rotation,
     onTransformation: ZoomableState.(zoomChange: Float, panChange: Offset, rotationChange: Float) -> Unit
 ) : TransformableState {
@@ -61,6 +64,8 @@ public class ZoomableState(
     private val transformMutex = MutatorMutex()
 
     private val isTransformingState = mutableStateOf(false)
+
+    public var composableCenter: Offset by mutableStateOf(Offset.Zero)
 
 
     override suspend fun transform(
@@ -99,10 +104,17 @@ public class ZoomableState(
         }
     }
 
+
+    /**
+     * Animates a zoom towards the specified position
+     * @param zoomChange The zoom factor
+     * @param position The position to zoom towards
+     * @param currentComposableCenter The current center of the composable relative to the [Zoomable] container. Default might break if this state is used by multiple [Zoomable]s
+     */
     public suspend fun animateZoomToPosition(
         zoomChange: Float,
         position: Offset,
-        currentComposableCenter: Offset = Offset.Zero,
+        currentComposableCenter: Offset = composableCenter + offset.value,
         animationSpec: AnimationSpec<Float> = SpringSpec(stiffness = Spring.StiffnessLow)
     ) {
         val offsetBuffer = offset.value
@@ -125,7 +137,12 @@ public class ZoomableState(
         val transformOffset =
             position - (currentComposableCenter - offsetBuffer) - Offset(x1, y1)
 
-        animateBy(zoomChange = zoomChange, panChange = transformOffset, rotationChange = 0f, animationSpec)
+        animateBy(
+            zoomChange = zoomChange,
+            panChange = transformOffset,
+            rotationChange = 0f,
+            animationSpec
+        )
     }
 
     /**
@@ -148,6 +165,35 @@ public class ZoomableState(
          * Rotation gestures will not be detected
          */
         DISABLED
+    }
+
+
+    public inner class DefaultDoubleTapBehaviour(
+        private val zoomScale: Float = 2f,
+        private val animationSpec: AnimationSpec<Float> = SpringSpec(stiffness = Spring.StiffnessLow),
+        private val coroutineScope: CoroutineScope
+    ) : DoubleTapBehaviour {
+        override fun onDoubleTap(offset: Offset) {
+            if (scale.value != 1f) {
+                coroutineScope.launch {
+                    animateBy(
+                        zoomChange = 1 / scale.value,
+                        panChange = -this@ZoomableState.offset.value,
+                        rotationChange = -rotation.value,
+                        animationSpec = animationSpec
+                    )
+                }
+            } else {
+                coroutineScope.launch {
+                    animateZoomToPosition(
+                        zoomScale,
+                        position = offset,
+                        composableCenter,
+                        animationSpec = animationSpec
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/zoomables/src/main/kotlin/de/mr_pine/zoomables/ZoomableState.kt
+++ b/zoomables/src/main/kotlin/de/mr_pine/zoomables/ZoomableState.kt
@@ -48,7 +48,7 @@ public class ZoomableState(
 ) : TransformableState {
 
     public val zoomed: Boolean
-        get() = scale.value in (1 - zoomedThreshold)..(1 + zoomedThreshold)
+        get() = scale.value !in (1 - zoomedThreshold)..(1 + zoomedThreshold)
 
     public val transformed: Boolean
         get() = zoomed || offset.value.getDistanceSquared() !in -1.0E-6f..1.0E-6f || rotation.value !in -1.0E-3f..1.0E-3f
@@ -102,7 +102,8 @@ public class ZoomableState(
     public suspend fun animateZoomToPosition(
         zoomChange: Float,
         position: Offset,
-        currentComposableCenter: Offset = Offset.Zero
+        currentComposableCenter: Offset = Offset.Zero,
+        animationSpec: AnimationSpec<Float> = SpringSpec(stiffness = Spring.StiffnessLow)
     ) {
         val offsetBuffer = offset.value
 
@@ -124,7 +125,7 @@ public class ZoomableState(
         val transformOffset =
             position - (currentComposableCenter - offsetBuffer) - Offset(x1, y1)
 
-        animateBy(zoomChange = zoomChange, panChange = transformOffset, rotationChange = 0f)
+        animateBy(zoomChange = zoomChange, panChange = transformOffset, rotationChange = 0f, animationSpec)
     }
 
     /**

--- a/zoomables/src/main/kotlin/de/mr_pine/zoomables/ZoomableState.kt
+++ b/zoomables/src/main/kotlin/de/mr_pine/zoomables/ZoomableState.kt
@@ -2,15 +2,27 @@
 
 package de.mr_pine.zoomables
 
-import androidx.compose.animation.core.*
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.AnimationState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.animation.core.animateTo
 import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.MutatorMutex
 import androidx.compose.foundation.gestures.TransformScope
 import androidx.compose.foundation.gestures.TransformableState
 import androidx.compose.foundation.gestures.rememberTransformableState
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
-import de.mr_pine.zoomables.ZoomableState.Rotation.*
+import de.mr_pine.zoomables.ZoomableState.Rotation.ALWAYS_ENABLED
+import de.mr_pine.zoomables.ZoomableState.Rotation.DISABLED
+import de.mr_pine.zoomables.ZoomableState.Rotation.LOCK_ROTATION_ON_ZOOM_PAN
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -174,7 +186,7 @@ public class ZoomableState(
         private val coroutineScope: CoroutineScope
     ) : DoubleTapBehaviour {
         override fun onDoubleTap(offset: Offset) {
-            if (scale.value != 1f) {
+            if (transformed) {
                 coroutineScope.launch {
                     animateBy(
                         zoomChange = 1 / scale.value,


### PR DESCRIPTION
- Fix default dragGestureMode (was inverted)
- Call onTransformation when single Finger dragging
- Add DragGestureMode.default
- DragGestureMode.default and ZoomableState.DefaultDoubleTapBehaviour change on `transformed` instead of `zoomed`